### PR TITLE
Update go to 1.25 and add bats tests

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -34,14 +34,12 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -53,6 +51,18 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      -
+        name: Install BATS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      -
+        name: Run BATS tests
+        run: |
+          IMAGE_REF="${{ steps.meta.outputs.tags }}"
+          IMAGE_NAME=$(echo "$IMAGE_REF" | head -n1) bats envplate.bats

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1
 # Build docker-gen from scratch
-FROM golang:1.23-alpine AS ep-builder
+FROM golang:1.25-alpine AS ep-builder
 
-ARG VERSION=v1.0.3
+ARG VERSION=v1.0.4-rc.1
 
-ADD https://github.com/kreuzwerker/envplate.git#${VERSION} /build
+# Pinning at https://github.com/kreuzwerker/envplate/commit/ec00ede3ca03c6bbbe0412bf4b84eacdcdabba11
+ADD https://github.com/kreuzwerker/envplate.git#ec00ede3ca03c6bbbe0412bf4b84eacdcdabba11 /build
 
 WORKDIR /build
 

--- a/envplate.bats
+++ b/envplate.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+# Setup and teardown
+setup() {
+    export TEST_DIR=$(mktemp -d)
+    export IMAGE_NAME="${IMAGE_NAME:-local/ep:latest}"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "basic variable substitution" {
+    echo 'Value: ${TEST_VAR}' > "$TEST_DIR/config.txt"
+    
+    run docker run --rm \
+        -e TEST_VAR=hello \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep /test/config.txt
+    
+    [ "$status" -eq 0 ]
+    
+    result=$(cat "$TEST_DIR/config.txt")
+    [ "$result" = "Value: hello" ]
+}
+
+@test "default value handling" {
+    echo 'Database: ${DB_HOST:-localhost}' > "$TEST_DIR/config.txt"
+    
+    run docker run --rm \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep /test/config.txt
+    
+    [ "$status" -eq 0 ]
+    
+    result=$(cat "$TEST_DIR/config.txt")
+    [ "$result" = "Database: localhost" ]
+}
+
+@test "backup creation" {
+    echo 'Value: ${TEST_VAR}' > "$TEST_DIR/config.txt"
+    
+    run docker run --rm \
+        -e TEST_VAR=hello \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep -b /test/config.txt
+    
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DIR/config.txt.bak" ]
+    
+    # Original content should be in backup
+    backup_content=$(cat "$TEST_DIR/config.txt.bak")
+    [ "$backup_content" = "Value: \${TEST_VAR}" ]
+    
+    # Processed content should be in original file
+    processed_content=$(cat "$TEST_DIR/config.txt")
+    [ "$processed_content" = "Value: hello" ]
+}
+
+@test "strict mode fails on missing variables" {
+    echo 'Value: ${MISSING_VAR}' > "$TEST_DIR/config.txt"
+    
+    run docker run --rm \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep -s /test/config.txt
+    
+    [ "$status" -ne 0 ]
+}
+
+@test "escaped variables are not processed" {
+    echo 'Escaped: \${TEST_VAR}' > "$TEST_DIR/config.txt"
+    
+    run docker run --rm \
+        -e TEST_VAR=hello \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep /test/config.txt
+    
+    [ "$status" -eq 0 ]
+    
+    result=$(cat "$TEST_DIR/config.txt")
+    [ "$result" = "Escaped: \${TEST_VAR}" ]
+}
+
+@test "dry run outputs to stdout" {
+    echo 'Value: ${TEST_VAR}' > "$TEST_DIR/config.txt"
+    
+    run docker run --rm \
+        -e TEST_VAR=hello \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep -d /test/config.txt
+    
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Value: hello" ]]
+    
+    # Original file should be unchanged
+    original_content=$(cat "$TEST_DIR/config.txt")
+    [ "$original_content" = "Value: \${TEST_VAR}" ]
+}
+
+@test "multiple files with glob pattern" {
+    echo 'env=${ENV}' > "$TEST_DIR/app.conf"
+    echo 'environment=${ENV}' > "$TEST_DIR/db.conf"
+    
+    run docker run --rm \
+        -e ENV=production \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep '/test/*.conf'
+    
+    [ "$status" -eq 0 ]
+    
+    app_result=$(cat "$TEST_DIR/app.conf")
+    db_result=$(cat "$TEST_DIR/db.conf")
+    [ "$app_result" = "env=production" ]
+    [ "$db_result" = "environment=production" ]
+}
+
+@test "exec functionality works" {
+    echo 'Message: ${MESSAGE}' > "$TEST_DIR/output.txt"
+    echo 'Message: ${MESSAGE}${MESSAGE}' > "$TEST_DIR/output_exec.txt"
+    
+    run docker run --rm \
+        -e MESSAGE=hello \
+        -v "$TEST_DIR:/test" \
+        "$IMAGE_NAME" \
+        ep -b /test/output.txt -- /usr/local/bin/ep -d /test/output_exec.txt
+    
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Message: hellohello" ]]
+}
+
+@test "version information available" {
+    run docker run --rm "$IMAGE_NAME" ep --help
+    
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "envplate" ]]
+}
+
+@test "container uses scratch base (minimal size)" {
+    run docker images "$IMAGE_NAME" --format "{{.Size}}"
+    
+    [ "$status" -eq 0 ]
+    # Size should be less than 20MB for a scratch-based image
+    size_mb=$(echo "$output" | sed 's/MB//' | cut -d'.' -f1)
+    [ -n "$size_mb" ]
+    [ "$size_mb" -lt 20 ]
+}


### PR DESCRIPTION
This PR updates the version of Go used to build the image to 1.25

It also adds a range of very basic functionality tests to the image build process