### PR TITLE
chore: setup a weekly govulncheck for the binary image

### DIFF
--- a/.github/workflows/weekly_govulncheck.yml
+++ b/.github/workflows/weekly_govulncheck.yml
@@ -1,0 +1,68 @@
+name: Weekly Go Vulnerability Check
+
+on:
+  schedule:
+    # Runs every Monday at 03:00 UTC.
+    - cron: "0 3 * * 1"
+  push:
+    branches:
+      - "main"
+      - "govulncheck"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REF: ghcr.io/amazeeio/envplate:latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Pull image
+        run: docker pull "$IMAGE_REF"
+
+      - name: Extract ep binary from image
+        run: |
+          CONTAINER_ID=$(docker create "$IMAGE_REF")
+          trap 'docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true' EXIT
+          docker cp "$CONTAINER_ID":/usr/local/bin/ep ./ep
+          chmod +x ./ep
+
+      - name: Run govulncheck and capture output
+        id: run_govulncheck
+        shell: bash
+        run: |
+          set +e
+          govulncheck -mode binary ./ep | tee govulncheck.out
+          GOVULN_EXIT=${PIPESTATUS[0]}
+          echo "exit_code=${GOVULN_EXIT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish govulncheck summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## govulncheck result"
+            echo
+            echo "Image: $IMAGE_REF"
+            echo "Exit code: ${{ steps.run_govulncheck.outputs.exit_code }}"
+            echo
+            echo '```text'
+            cat govulncheck.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if vulnerabilities were found
+        if: ${{ steps.run_govulncheck.outputs.exit_code != '0' }}
+        run: |
+          echo "govulncheck reported vulnerabilities. See summary for details."
+          exit 1

--- a/.github/workflows/weekly_govulncheck.yml
+++ b/.github/workflows/weekly_govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     env:
-      IMAGE_REF: ghcr.io/amazeeio/envplate:latest
+      IMAGE_REF: ghcr.io/${{ github.repository_owner }}/envplate:latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -50,14 +50,19 @@ jobs:
         if: always()
         shell: bash
         run: |
+          EXIT_CODE="${{ steps.run_govulncheck.outputs.exit_code }}"
           {
             echo "## govulncheck result"
             echo
             echo "Image: $IMAGE_REF"
-            echo "Exit code: ${{ steps.run_govulncheck.outputs.exit_code }}"
+            echo "Exit code: ${EXIT_CODE:-unavailable}"
             echo
             echo '```text'
-            cat govulncheck.out
+            if [ -f govulncheck.out ]; then
+              cat govulncheck.out
+            else
+              echo "govulncheck output was not generated because the scan step was skipped or failed before producing output."
+            fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate weekly vulnerability checks on the Go binary extracted from the project's Docker image. The workflow ensures that any vulnerabilities found by Go's `govulncheck` tool are reported and cause the workflow to fail, helping maintain code security.

**Security automation:**

* Adds a new workflow file `.github/workflows/weekly_govulncheck.yml` that runs `govulncheck` on the `ep` binary extracted from the Docker image every Monday at 03:00 UTC, as well as on pushes to `main` and `govulncheck` branches, and on manual dispatch.
* The workflow installs Go, pulls the latest Docker image, extracts the `ep` binary, runs `govulncheck` in binary mode, and publishes a summary of the results to the GitHub Actions summary.
* If vulnerabilities are detected (non-zero exit code), the workflow fails and notifies maintainers in the summary.

**Sample Error:**
<img width="1880" height="824" alt="image" src="https://github.com/user-attachments/assets/920961df-335e-40db-b07a-30bb3752a615" />
